### PR TITLE
Avoid GC allocation

### DIFF
--- a/src/render.d
+++ b/src/render.d
@@ -34,9 +34,9 @@ void drawFrame(ref App app) {
   app.synchronization.imagesInFlight[imageIndex] = app.synchronization.inFlightFences[app.currentFrame];
   
   //SDL_Log("Renderer next frame %d image = %d", frame, imageIndex);
-  VkSemaphore[] waitSemaphores = [app.synchronization.imageAvailableSemaphores[app.currentFrame]];
-  VkPipelineStageFlags[] waitStages = [VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT];
-  VkSemaphore[] signalSemaphores = [app.synchronization.renderFinishedSemaphores[app.currentFrame]];
+  VkSemaphore[1] waitSemaphores = [app.synchronization.imageAvailableSemaphores[app.currentFrame]];
+  VkPipelineStageFlags[1] waitStages = [VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT];
+  VkSemaphore[1] signalSemaphores = [app.synchronization.renderFinishedSemaphores[app.currentFrame]];
 
   VkSubmitInfo submitInfo = {
     sType: VK_STRUCTURE_TYPE_SUBMIT_INFO,
@@ -55,7 +55,7 @@ void drawFrame(ref App app) {
   enforceVK(vkQueueSubmit(app.graphicsQueue, 1, &submitInfo, app.synchronization.inFlightFences[app.currentFrame]));
   //SDL_Log("vkQueueSubmit: %d", inFlightFences[currentFrame]);
 
-  VkSwapchainKHR[] swapChains = [app.swapchain.swapChain];
+  VkSwapchainKHR[1] swapChains = [app.swapchain.swapChain];
 
   VkPresentInfoKHR presentInfo = {
     sType: VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,


### PR DESCRIPTION
Since this is called everyframe, this could hurt perf, specially on mobile

If i remember correctly, ``VkSwapchainKHR[] swapChains = [app.swapchain.swapChain];`` will create the the GC heap, using a static array solves this