### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.java linguist-detectable=false


### PR DESCRIPTION
By default github think it is a java project because it has more java code

We can trick github by using a .gitattributes file

![image](https://user-images.githubusercontent.com/18348637/124386563-5233b100-dcdb-11eb-9e0a-bb1ca1c80ad1.png)
